### PR TITLE
adapt to 3.0.26

### DIFF
--- a/usr/share/openmediavault/mkconf/fstab.d/15unionfilesystems
+++ b/usr/share/openmediavault/mkconf/fstab.d/15unionfilesystems
@@ -49,7 +49,7 @@ $mhddfs = function ($mountPoint, array $sourceMounts, array $options, $createPol
 
 // Start processing entries.
 $context = ['username' => 'admin', 'role' => OMV_ROLE_ADMINISTRATOR];
-$objects = Rpc::call('UnionFilesystems', 'getList', ['start' => 0, 'limit' => null], $context, OMV_RPC_MODE_REMOTE);
+$objects = Rpc::call('UnionFilesystems', 'getList', ['start' => 0, 'limit' => null], $context, \OMV\Rpc\Rpc::MODE_REMOTE);
 
 foreach ($objects['data'] as $object) {
     $mountPoint = UnionFilesystem::buildMountPath($object['uuid']);
@@ -61,7 +61,7 @@ foreach ($objects['data'] as $object) {
     $minFreeSpace = $object['min-free-space'];
 
     foreach ($object['mntentref'] as $mntentref) {
-        $mntent = Rpc::call('FsTab', 'get', ['uuid' => $mntentref], $context, OMV_RPC_MODE_REMOTE);
+        $mntent = Rpc::call('FsTab', 'get', ['uuid' => $mntentref], $context, \OMV\Rpc\Rpc::MODE_REMOTE);
         $sourceMounts[] = $mntent['dir'];
     }
 

--- a/usr/share/php/openmediavault/system/filesystem/union.inc
+++ b/usr/share/php/openmediavault/system/filesystem/union.inc
@@ -25,7 +25,7 @@ use OMV\Config\DatabaseException;
 use OMV\ExecException;
 use OMV\System\Process;
 
-class Union extends FilesystemAbstract
+class Union extends Filesystem
 {
     /** @var Database */
     private $database;


### PR DESCRIPTION
In omv 3.0.26, omv-ufs doesn't works
it cannot create or list ufs since FilesystemAbstract is removed in 3.0.26
and OMV_RPC_MODE_REMOTE is renamed to \OMV\Rpc\Rpc::MODE_REMOTE

**note**
from jessie-backports, aufs is not included in kernel
so aufs will not works on jessie-backports