### PR TITLE
Get mount point when using fsname, fix #25

### DIFF
--- a/usr/share/php/openmediavault/system/filesystem/backend/mergerfs.inc
+++ b/usr/share/php/openmediavault/system/filesystem/backend/mergerfs.inc
@@ -55,9 +55,10 @@ class Mergerfs extends UnionAbstract
             // Assume we got the mount directory.
             $mountPoint = $args;
 
-            // Check if it's the real fsname and handle it (the real fsname
-            // contains ':' to separate the branches).
-            if (strpos($args, ':') !== false) {
+            // Check if it's the real fsname or if a fsname has been given and handle it (the real fsname
+            // contains ':' to separate the branches, there's likely no DIRECTORY_SEPARATOR in a given name,
+            // maybe this should be enforced).
+            if (strpos($args, ':') !== false || strpos($args, DIRECTORY_SEPARATOR) === false) {
                 $mountPoint = self::fetchMountPointFromFstabByFsnameAndType($args, $this->type);
             }
 


### PR DESCRIPTION
As noted in the comment, maybe the fsname option should be handled by the plugin to disallow usage of `/` (`DIRECTORY_SEPARATOR`) (which doesn't seems to be disallowed by fuse when I see https://github.com/osxfuse/osxfuse/wiki/Mount-options#fsname), which might confuse everyone.
A workaround without the fix, is to use a `fsname` containing `:` like `mergerfs:data`.