### PR TITLE
make salt mount.mounted to mount only when the fuse point is not mounted

### DIFF
--- a/srv/salt/omv/deploy/fstab/15unionfilesystems.sls
+++ b/srv/salt/omv/deploy/fstab/15unionfilesystems.sls
@@ -5,7 +5,10 @@
   'conf.system.filesystem.mountpoint',
   {'operator':'stringEquals', 'arg0':'uuid', 'arg1':pool.self_mntentref}) %}
 {% set mntDir = poolmount[0].dir %}
-
+{% set mount = True %}
+{% if salt['mount.is_mounted'](mntDir) %}
+  {% set mount = False %}
+{% endif %}
 {% set options = [] %}
 {% set options = pool.options.split(',') %}
 {% set _ = options.append('category.create=' + pool.create_policy) %}

--- a/srv/salt/omv/deploy/fstab/15unionfilesystems.sls
+++ b/srv/salt/omv/deploy/fstab/15unionfilesystems.sls
@@ -39,5 +39,5 @@ mount_filesystem_mountpoint_{{ pool.self_mntentref }}:
     - opts: {{ options }}
     - mkmnt: True
     - persist: False
-    - mount: True
+    - mount: {{ mount }}
 {% endfor %}


### PR DESCRIPTION
this is to prevent errors when the fuse point is in use by a service. As the old mkconf just echoed to fstab, salt goes beyond and attempts a remount this ends in error if in use.

https://forum.openmediavault.org/index.php?thread/31529-mergerfs-salt-always-issues-when-changing-something/&postID=233067